### PR TITLE
feat: add option to set remote host/port netcat location

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Options:
   --profile AWS_PROFILE_NAME
   --aws-exec BIN                  aws command line executable. (default:
                                   "aws")
+  --remote-port-netcat-exec REMOTE_PORT_NETCAT_EXEC
+                                  Remote port netcat command line executable.
+                                  (default: "nc")
   --verbose
   --version                       Show the version and exit.
   --help                          Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ ecs-tunnel -L 5432:my-db-cluster:5432 -c my-cluster -t 7e2c99a9c63eb1fc3949d9e96
 
 Setup HTTP proxy on port 8888:
 ```
-ecs-tunnel -D 8888 -c my-cluster -t 7e2c99a9c63eb1fc3949d9e966d91f3b
+ecs-tunnel -H 8888 -c my-cluster -t 7e2c99a9c63eb1fc3949d9e966d91f3b
 ```
 
 
 ## But How?
 
 Port forwarding to a port on an EC2 node is currently supported and documented using AWS Systems Manager,
- AWS Session Manager Plugin and the `aws session` command. 
-By observing how `aws ecs execute-command` also used the AWS Session Manager, and taking insperation from SSH 
-port forwarding, it was possible to write a quick wrapper that used the EC2 port forwarding profile with 
+ AWS Session Manager Plugin and the `aws session` command.
+By observing how `aws ecs execute-command` also used the AWS Session Manager, and taking insperation from SSH
+port forwarding, it was possible to write a quick wrapper that used the EC2 port forwarding profile with
 ECS tasks.
 
 Unfortunately, the AWS Systems Manager doesn't seem to expose a way of forwading a local port to a remote
@@ -104,4 +104,4 @@ port via the connected task. Instead, we use compatible versions of netcat to pr
 ## Todo
 
 - Check for remote netcat support
-- Implement native Python session-manager using websockets 
+- Implement native Python session-manager using websockets

--- a/ecs_tunnel/_ecs_tunnel.py
+++ b/ecs_tunnel/_ecs_tunnel.py
@@ -223,18 +223,6 @@ class EcsTunnel:
 
         return self.local_port_tunnel(local_port=local_port, remote_port=remote_port)
 
-    def remote_port_tunnel_pexpect(self, remote_port: int, remote_host: str, local_port=None):
-
-        aws_cmd = {
-            'execute-command',
-            '--cluster', self.cluster_id,
-            '--command', '/usr/bin/bash',
-            '--interactive',
-            '--task', self.task_id
-        }
-
-        child = pexpect.spawn(command=self._resolved_aws_cli_exec, args=aws_cmd, env=self._get_env())
-
     def close(self):
         self._logger.debug('Trying to kill running exec sessions')
         for exec_session in self._ecs_exec_sessions:

--- a/ecs_tunnel/_ecs_tunnel.py
+++ b/ecs_tunnel/_ecs_tunnel.py
@@ -22,6 +22,7 @@ class EcsTunnel:
     task_id: str
     container_name: typing.Optional[str]
     aws_cli_exec: str
+    remote_port_netcat_exec: str
 
     def __init__(
             self,
@@ -34,6 +35,7 @@ class EcsTunnel:
             aws_session_token: str = None,
             aws_region_name: str = None,
             aws_profile_name: str = None,
+            remote_port_netcat_exec: str = 'nc',
 
     ):
         self.cluster_id = cluster_id
@@ -41,6 +43,7 @@ class EcsTunnel:
         self.container_name = container_name
 
         self.aws_cli_exec = aws_cli_exec
+        self.remote_port_netcat_exec = remote_port_netcat_exec
 
         self._logger = logging.getLogger('ecs_tunnel')
 
@@ -209,7 +212,7 @@ class EcsTunnel:
         # TODO: check in use
         proxy_port = self._get_port()
 
-        netcat_cmd = f'nc -lk -p {proxy_port} -e nc {remote_host} {remote_port}'
+        netcat_cmd = f'{self.remote_port_netcat_exec} -lk -p {proxy_port} -e "{self.remote_port_netcat_exec} {remote_host} {remote_port}"'
         self._run_remote_ecs_cmd(cmd=netcat_cmd)
 
         return self.local_port_tunnel(local_port=local_port, remote_port=proxy_port)

--- a/ecs_tunnel/cli.py
+++ b/ecs_tunnel/cli.py
@@ -80,9 +80,12 @@ REMOTE_ADDR is optional. If given, netcat is required on the connected task. Req
 @click.option(
     '--aws-exec', metavar='BIN', help='aws command line executable. (default: "aws")', default='aws'
 )
+@click.option(
+    '--remote-port-netcat-exec', metavar='REMOTE_PORT_NETCAT_EXEC', help='Remote port netcat command line executable. (default: "nc")', default='nc'
+)
 @click.option('--verbose', is_flag=True, default=False)
 @click.version_option(version=VERSION)
-def cli(cluster, task, container, local, http_proxy, region, profile, aws_exec, verbose):
+def cli(cluster, task, container, local, http_proxy, region, profile, aws_exec, remote_port_netcat_exec, verbose):
     action = False
 
     if verbose:
@@ -90,7 +93,7 @@ def cli(cluster, task, container, local, http_proxy, region, profile, aws_exec, 
 
     et = EcsTunnel(
         cluster_id=cluster, task_id=task, container_name=container, aws_profile_name=profile, aws_region_name=region,
-        aws_cli_exec=aws_exec
+        aws_cli_exec=aws_exec, remote_port_netcat_exec=remote_port_netcat_exec
     )
 
     for lp in local:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.2.1'
+version = '0.3.0'
 
 with open('README.md', 'r') as f:
     long_description = f.read()


### PR DESCRIPTION
`ecs-tunnel -L $FORWARDED_PORT:$HOSTNAME:$PORT -c $cluster -t $taskId`

When using the above remote host/port fowarding, netcat was running:
`nc -lk -p 20591 -e nc myhost 1111`

And throwing:
`Ncat: Got more than one port specification: 20592 1111. QUITTING.`

Quoting the value:
`nc -lk -p 20591 -e "nc myhost 1111"`
Resulted in the following error (as it interprets `nc` as a file)
`exec: No such file or directory`

Passing an explicit `nc` location along with quoting resolves this and is backwards compatible.
`ecs-tunnel --remote-port-netcat-exec=/bin/nc -L $FORWARDED_PORT:$HOSTNAME:$PORT -c $cluster -t $taskId`
`/bin/nc -lk -p 20591 -e "/bin/nc myhost 1111"`